### PR TITLE
Delete image after database row deleted

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -46,7 +46,7 @@ class Image extends Model implements ResponsiveImage
     public static function boot()
     {
         parent::boot();
-        static::deleted(function (Image $image) {
+        static::deleted(function (self $image) {
             dispatch(new DeleteCloudImage($image->path));
         });
     }

--- a/src/Image.php
+++ b/src/Image.php
@@ -46,7 +46,7 @@ class Image extends Model implements ResponsiveImage
     public static function boot()
     {
         parent::boot();
-        static::deleting(function (Image $image) {
+        static::deleted(function (Image $image) {
             dispatch(new DeleteCloudImage($image->path));
         });
     }


### PR DESCRIPTION
Sometimes $image->delete() fails. In our case, this was due to a foreign key reference.

At present, the image is deleted from the storage and the DB row remains in place resulting in a missing image.

This change deletes the file from storage only after the DB row is successfully deleted.