### PR TITLE
Add Laravel 13 and PHP 8.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
             laravel: 12.*
           - php: 8.1
             laravel: 13.*
+          - php: 8.2
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - php: 8.1
             laravel: 11.*
           - php: 8.1
             laravel: 12.*
+          - php: 8.1
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -8,14 +8,14 @@
     },
     "require": {
         "php": "^8.1",
-        "illuminate/container": "^10.0|^11.0|^12.0",
-        "illuminate/filesystem": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/container": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/filesystem": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "spatie/laravel-google-cloud-storage": "^2.0",
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "laravel/laravel": "10.*|11.*|12.*",
+        "laravel/laravel": "10.*|11.*|12.*|13.*",
         "intervention/image": "^2.4",
         "doctrine/dbal": "^3.0",
         "mockery/mockery": "^1.5",


### PR DESCRIPTION
## Summary
- add Laravel 13 support to composer constraints
- add Laravel 13 and PHP 8.5 to the CI matrix
- exclude Laravel 13 on PHP 8.1, matching the existing lower-PHP exclusions
- update GitHub Actions checkout to v4 while touching the test workflow

## Testing
- composer update
- vendor/bin/phpunit
